### PR TITLE
Dockerfile for cuda11

### DIFF
--- a/docker/cuda11/Dockerfile
+++ b/docker/cuda11/Dockerfile
@@ -1,0 +1,33 @@
+FROM nvcr.io/nvidia/tensorflow:20.12-tf1-py3
+
+##################
+## Requirements ##
+##################
+RUN apt-get update && apt-get install -y git wget && \
+rm -rf /var/lib/apt/lists/*
+RUN export LD_LIBRARY_PATH=/usr/local/cuda/lib64
+
+###############
+## NMT-Keras ##
+###############
+RUN git clone https://github.com/PRHLT/nmt-keras_practicas-TA.git /opt/nmt-keras \
+&& cp /opt/nmt-keras/docker/config.py /opt/nmt-keras/config.py
+WORKDIR /opt/nmt-keras
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh && \
+bash /tmp/miniconda.sh -b -p /opt/miniconda && export PATH="/opt/miniconda/bin:$PATH" && \
+conda config --set always_yes yes --set changeps1 no && conda init && \
+conda install --file /opt/nmt-keras/req-travis-conda.txt && conda install mkl mkl-service pip && \
+pip install -r /opt/nmt-keras/req-travis-pip.txt && \
+pip install nvidia-pyindex && \
+pip install https://developer.download.nvidia.com/compute/redist/nvidia-tensorflow/nvidia_tensorflow-1.15.4%2Bnv20.12-cp38-cp38-linux_x86_64.whl && \
+
+export PATH=$PATH:$HOME/.local/bin
+ENV PYTHONPATH="PYTHONPATH=${PYTHONPATH}:/opt/nmt-keras/keras:\
+/opt/nmt-keras/coco-caption:/opt/nmt-keras/multimodal_keras_wrapper"
+
+##########################
+## Default: train model ##
+##########################
+CMD export PATH="/opt/miniconda/bin:$PATH" && \
+export LD_LIBRARY_PATH=/usr/local/cuda/lib64 && \
+python main.py


### PR DESCRIPTION
Hello!

So I was using your Dockerfile for nmt-keras and I realised it didt had support for cuda 11 (and so, no support for rtx 3000 gpus) so went ahead and created a new dockerfile to solve it. I created it under cuda11 folder but I didnt knew where to put it exactly, up to you to decide.

This dockerfile is based on nvidia fork for tensorflow 1.X to provide support for ampere gpus https://docs.nvidia.com/deeplearning/frameworks/tensorflow-release-notes/rel_19.01.html

The original dockerfile also needs to change tensorflow==1.4.1 to tensorflow-gpu==1.4.1 in case you want to run in gpu. 